### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/drawing.py
+++ b/drawing.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
@@ -209,7 +210,7 @@ def draw(
 
     if save_file is not None:
         plt.savefig(save_file)
-        print 'saved to {}'.format(save_file)
+        print('saved to {}'.format(save_file))
     else:
         plt.show()
     plt.close('all')

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 from xml.etree import ElementTree
 
@@ -54,7 +55,7 @@ def collect_data():
 
     stroke_fnames, transcriptions, writer_ids = [], [], []
     for i, fname in enumerate(fnames):
-        print i, fname
+        print(i, fname)
         if fname == 'data/raw/ascii/z01/z01-000/z01-000z.txt':
             continue
 
@@ -98,10 +99,10 @@ def collect_data():
 
 
 if __name__ == '__main__':
-    print 'traversing data directory...'
+    print('traversing data directory...')
     stroke_fnames, transcriptions, writer_ids = collect_data()
 
-    print 'dumping to numpy arrays...'
+    print('dumping to numpy arrays...')
     x = np.zeros([len(stroke_fnames), drawing.MAX_STROKE_LEN, 3], dtype=np.float32)
     x_len = np.zeros([len(stroke_fnames)], dtype=np.int16)
     c = np.zeros([len(stroke_fnames), drawing.MAX_CHAR_LEN], dtype=np.int8)
@@ -111,7 +112,7 @@ if __name__ == '__main__':
 
     for i, (stroke_fname, c_i, w_id_i) in enumerate(zip(stroke_fnames, transcriptions, writer_ids)):
         if i % 200 == 0:
-            print i, '\t', '/', len(stroke_fnames)
+            print(i, '\t', '/', len(stroke_fnames))
         x_i = get_stroke_sequence(stroke_fname)
         valid_mask[i] = ~np.any(np.linalg.norm(x_i[:, :2], axis=1) > 60)
 

--- a/rnn.py
+++ b/rnn.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 import numpy as np
@@ -20,9 +21,9 @@ class DataReader(object):
         self.test_df = DataFrame(columns=data_cols, data=data)
         self.train_df, self.val_df = self.test_df.train_test_split(train_size=0.95, random_state=2018)
 
-        print 'train size', len(self.train_df)
-        print 'val size', len(self.val_df)
-        print 'test size', len(self.test_df)
+        print('train size', len(self.train_df))
+        print('val size', len(self.val_df))
+        print('test size', len(self.test_df))
 
     def train_batch_generator(self, batch_size):
         return self.batch_generator(

--- a/tf_base_model.py
+++ b/tf_base_model.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from collections import deque
 from datetime import datetime
 import logging
@@ -146,7 +147,7 @@ class TFBaseModel(object):
 
                 # validation evaluation
                 val_start = time.time()
-                val_batch_df = val_generator.next()
+                val_batch_df = next(val_generator)
                 val_feed_dict = {
                     getattr(self, placeholder_name, None): data
                     for placeholder_name, data in val_batch_df.items() if hasattr(self, placeholder_name)
@@ -173,19 +174,19 @@ class TFBaseModel(object):
                 if hasattr(self, 'monitor_tensors'):
                     for name, tensor in self.monitor_tensors.items():
                         [np_val] = self.session.run([tensor], feed_dict=val_feed_dict)
-                        print name
-                        print 'min', np_val.min()
-                        print 'max', np_val.max()
-                        print 'mean', np_val.mean()
-                        print 'std', np_val.std()
-                        print 'nans', np.isnan(np_val).sum()
-                        print
-                    print
-                    print
+                        print(name)
+                        print('min', np_val.min())
+                        print('max', np_val.max())
+                        print('mean', np_val.mean())
+                        print('std', np_val.std())
+                        print('nans', np.isnan(np_val).sum())
+                        print()
+                    print()
+                    print()
 
                 # train step
                 train_start = time.time()
-                train_batch_df = train_generator.next()
+                train_batch_df = next(train_generator)
                 train_feed_dict = {
                     getattr(self, placeholder_name, None): data
                     for placeholder_name, data in train_batch_df.items() if hasattr(self, placeholder_name)
@@ -272,7 +273,7 @@ class TFBaseModel(object):
             test_generator = self.reader.test_batch_generator(chunk_size)
             for i, test_batch_df in enumerate(test_generator):
                 if i % 10 == 0:
-                    print i*len(test_batch_df)
+                    print(i*len(test_batch_df))
 
                 test_feed_dict = {
                     getattr(self, placeholder_name, None): data
@@ -337,7 +338,10 @@ class TFBaseModel(object):
         date_str = datetime.now().strftime('%Y-%m-%d_%H-%M')
         log_file = 'log_{}.txt'.format(date_str)
 
-        reload(logging)  # bad
+        try:                 # Python 2
+            reload(logging)  # bad
+        except NameError:    # Python 3
+            import logging
         logging.basicConfig(
             filename=os.path.join(log_dir, log_file),
             level=self.logging_level,


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
