### PR TITLE
Fix a small bug on windows system

### DIFF
--- a/prepare_data.py
+++ b/prepare_data.py
@@ -47,7 +47,7 @@ def collect_data():
         for filename in filenames:
             if filename.startswith('.'):
                 continue
-            fnames.append(os.path.join(dirpath, filename))
+            fnames.append(os.path.join(dirpath, filename).replace('\\', '/'))
 
     # low quality samples (selected by collecting samples to
     # which the trained model assigned very low likelihood)


### PR DESCRIPTION
When I tried to run `prepare_data.py` on Windows System, I was having the error: `assert len(ascii_sequences) == len(line_stroke_fnames)  AssertionError`. This is because on Windows system, `os.path.join()` gets the path concatenation character '\\', so the path from line 50 of `prepare_data.py` would look like this: `data/raw/ascii/z01\z01-000\z01-000z.txt`, causing line 59 to be inaccessible and skipping the loop.
By changing `fnames.append(os.path.join(dirpath, filename))` with` fnames.append(os.path.join(dirpath, filename).replace('\\', '/'))` in line 50, the error removed, and successfully processed the data.